### PR TITLE
Store step2 AutoLayout 정리

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - Decodable 활용하여 StoreItems 구조체 안에 StoreItem 배열을 넣었습니다.
 - MenuTableViewCell 에 해당 IndexPath 순서에 맞는 StoreItem 데이터를 넘기고, 텍스트 정보를 표시하였습니다.
 - HeaderView 구현과 상품기본가격이 없을 때 할인가격 Label 왼쪽 여백 조정이 필요합니다.
-![simulator screen shot - iphone 8 plus - 2018-07-08 at 13 41 13](https://user-images.githubusercontent.com/1483784/42416993-34ae73ca-82b8-11e8-84bf-e7a483de3193.png)
+<img src="https://user-images.githubusercontent.com/1483784/42416993-34ae73ca-82b8-11e8-84bf-e7a483de3193.png" width="414">
 
 ## Step 2
 
@@ -16,8 +16,8 @@
 - 모든 아이폰 사이즈에 대응해서 잘리는 화면이 없이 나와야 한다.
 - 상품기본가격이 없을 때 할인가격 Label 왼쪽 여백 조정을 하였습니다. 스토리보드에서 LayoutConstraint 을 IBOutlet 변수로 선언하여 처리하였습니다.
 - badge 값에 따라 이벤트 뱃지 노출 처리하였습니다.
-![simulator screen shot - iphone 5s - 2018-07-08 at 13 58 35](https://user-images.githubusercontent.com/1483784/42417000-4851b7ac-82b8-11e8-84d7-3af25d8fe080.png)
-![simulator screen shot - iphone x - 2018-07-08 at 13 57 08](https://user-images.githubusercontent.com/1483784/42416994-3520740c-82b8-11e8-9e0f-7e780e3b995f.png)
+<img src="https://user-images.githubusercontent.com/1483784/42417000-4851b7ac-82b8-11e8-84d7-3af25d8fe080.png" width="320">
+<img src="https://user-images.githubusercontent.com/1483784/42416994-3520740c-82b8-11e8-9e0f-7e780e3b995f.png" width="375">
 
 # 진행 방법
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,24 @@
+# 진행사항
+
+## Step 1
+
+- 상품목록 구현하였습니다.
+- main.json 파일을 읽어서 상품목록 데이터를 조회하였습니다.
+- Decodable 활용하여 StoreItems 구조체 안에 StoreItem 배열을 넣었습니다.
+- MenuTableViewCell 에 해당 IndexPath 순서에 맞는 StoreItem 데이터를 넘기고, 텍스트 정보를 표시하였습니다.
+- HeaderView 구현과 상품기본가격이 없을 때 할인가격 Label 왼쪽 여백 조정이 필요합니다.
+![simulator screen shot - iphone 8 plus - 2018-07-08 at 13 41 13](https://user-images.githubusercontent.com/1483784/42416993-34ae73ca-82b8-11e8-84bf-e7a483de3193.png)
+
+## Step 2
+
+- AutoLayout 정리
+- 스토리보드 ViewController에 Cell을 Content View를 기준으로 하위 뷰들에 오토레이아웃을 적용한다.
+- 모든 아이폰 사이즈에 대응해서 잘리는 화면이 없이 나와야 한다.
+- 상품기본가격이 없을 때 할인가격 Label 왼쪽 여백 조정을 하였습니다. 스토리보드에서 LayoutConstraint 을 IBOutlet 변수로 선언하여 처리하였습니다.
+- badge 값에 따라 이벤트 뱃지 노출 처리하였습니다.
+![simulator screen shot - iphone 5s - 2018-07-08 at 13 58 35](https://user-images.githubusercontent.com/1483784/42417000-4851b7ac-82b8-11e8-84d7-3af25d8fe080.png)
+![simulator screen shot - iphone x - 2018-07-08 at 13 57 08](https://user-images.githubusercontent.com/1483784/42416994-3520740c-82b8-11e8-9e0f-7e780e3b995f.png)
+
 # 진행 방법
 
 - 쇼핑 iOS 앱 요구사항을 파악한다.

--- a/StoreApp/StoreApp/Base.lproj/Main.storyboard
+++ b/StoreApp/StoreApp/Base.lproj/Main.storyboard
@@ -104,6 +104,7 @@
                                             <outlet property="menuImageView" destination="HPf-iM-NnU" id="LkI-Xo-YmZ"/>
                                             <outlet property="originalPriceLabel" destination="g9d-bG-JeJ" id="uBH-5P-7OM"/>
                                             <outlet property="salePriceLabel" destination="nP9-Ev-1cz" id="7fC-LP-cY5"/>
+                                            <outlet property="salePriceLabelLeadingConstraint" destination="mKF-Yg-Mu5" id="cvK-vR-fXD"/>
                                             <outlet property="titleLabel" destination="bX2-KI-5tX" id="88x-rr-ao2"/>
                                         </connections>
                                     </tableViewCell>

--- a/StoreApp/StoreApp/MenuTableViewCell.swift
+++ b/StoreApp/StoreApp/MenuTableViewCell.swift
@@ -17,6 +17,7 @@ class MenuTableViewCell: UITableViewCell {
     @IBOutlet weak var salePriceLabel: UILabel!
     @IBOutlet weak var badge1Label: UILabel!
     @IBOutlet weak var badge2Label: UILabel!
+    @IBOutlet weak var salePriceLabelLeadingConstraint: NSLayoutConstraint!
     
     var storeItem: StoreItem? {
         didSet {
@@ -26,7 +27,26 @@ class MenuTableViewCell: UITableViewCell {
             self.salePriceLabel.text = storeItem?.s_price
             self.badge1Label.text = storeItem?.badge1
             self.badge2Label.text = storeItem?.badge2
+            
+            setupViews()
         }
+    }
+    
+    private func setupViews() {
+        if let text = originalPriceLabel.text, text != "" {
+            salePriceLabelLeadingConstraint.constant = 4.0
+        } else {
+            salePriceLabelLeadingConstraint.constant = 0.0
+        }
+        badge1Label.isHidden = shouldHidden(label: badge1Label)
+        badge2Label.isHidden = shouldHidden(label: badge2Label)
+    }
+    
+    private func shouldHidden(label: UILabel) -> Bool {
+        if let text = label.text, text != "" {
+            return false
+        }
+        return true
     }
     
     override func awakeFromNib() {


### PR DESCRIPTION
**구현목적**
- 스토리보드 ViewController에 Cell을 Content View를 기준으로 하위 뷰들에 오토레이아웃을 적용한다.
- 모든 아이폰 사이즈에 대응해서 잘리는 화면이 없이 나와야 한다.

**구현내용**
- 상품기본가격이 없을 때 할인가격 Label 왼쪽 여백 조정을 하였습니다. 스토리보드에서 LayoutConstraint 을 IBOutlet 변수로 선언하여 처리하였습니다.
- badge 값에 따라 이벤트 뱃지 노출 처리하였습니다.
